### PR TITLE
Added EntityGraphUtils.fromAttributePaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,18 @@ productRepository.findOne(1L, EntityGraphUtils.fromName("Product.brand"));
 
 Or any method you like.
 
-You can also pass a dynamically built EntityGraph by using `DynamicEntityGraph` implementation.
+You can also pass a dynamically built EntityGraph by using `DynamicEntityGraph`, it's also accessible through a helper method:
+
+```java
+productRepository.findOne(1L, EntityGraphUtils.fromAttributePaths("brand", "maker"));
+```
+
+This is similar to [Spring's ad-hoc attribute paths](http://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-property-expressions),
+and equivalent to writing this in your repository's interface:
+```java
+@EntityGraph(attributePaths = { "brand", "maker" })
+Product findOne(Long id);
+```
 
 ## Default EntityGraph
 

--- a/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain/EntityGraphUtils.java
+++ b/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain/EntityGraphUtils.java
@@ -1,5 +1,8 @@
 package com.cosium.spring.data.jpa.entity.graph.domain;
 
+import com.mysema.commons.lang.Assert;
+
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -36,6 +39,15 @@ public class EntityGraphUtils {
 		NamedEntityGraph namedEntityGraph = new NamedEntityGraph(name);
 		namedEntityGraph.setOptional(optional);
 		return namedEntityGraph;
+	}
+
+	/**
+	 * @param attributePaths The attribute paths to be present in the result
+	 * @return A {@link DynamicEntityGraph} with the path attributes passed in as arguments.
+	 */
+	public static EntityGraph fromAttributePaths(String... attributePaths) {
+		Assert.notEmpty(attributePaths, "At least one attribute path is required.");
+		return new DynamicEntityGraph(Arrays.asList(attributePaths));
 	}
 
 	private static final class EmptyEntityGraph implements EntityGraph {

--- a/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/JpaEntityGraphRepositoryTest.java
+++ b/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/JpaEntityGraphRepositoryTest.java
@@ -11,6 +11,7 @@ import javax.persistence.criteria.Root;
 import java.util.List;
 
 import com.cosium.spring.data.jpa.entity.graph.BaseTest;
+import com.cosium.spring.data.jpa.entity.graph.domain.EntityGraph;
 import com.cosium.spring.data.jpa.entity.graph.domain.EntityGraphUtils;
 import com.cosium.spring.data.jpa.entity.graph.repository.exception.InapplicableEntityGraphException;
 import com.cosium.spring.data.jpa.entity.graph.repository.sample.*;
@@ -66,6 +67,25 @@ public class JpaEntityGraphRepositoryTest extends BaseTest {
 		Product product = productRepository.findOne(1L, EntityGraphUtils.fromName(Product.BRAND_EG, true));
 		assertThat(product).isNotNull();
 		assertThat(Hibernate.isInitialized(product.getBrand())).isTrue();
+	}
+
+	@Transactional
+	@Test
+	public void given_brand_in_attribute_paths_eg_when_findone_then_brand_should_be_loaded() {
+		Product product = productRepository.findOne(1L, EntityGraphUtils.fromAttributePaths(Product.BRAND_PROP_NAME));
+		assertThat(product).isNotNull();
+		assertThat(Hibernate.isInitialized(product.getBrand())).isTrue();
+	}
+
+	@Transactional
+	@Test
+	public void given_brand_and_maker_in_attribute_paths_eg_when_findone_then_brand_and_maker_should_be_loaded() {
+		EntityGraph entityGraph = EntityGraphUtils.fromAttributePaths(Product.BRAND_PROP_NAME, Product.MAKER_PROP_NAME);
+		Product product = productRepository.findOne(1L, entityGraph);
+
+		assertThat(product).isNotNull();
+		assertThat(Hibernate.isInitialized(product.getBrand())).isTrue();
+		assertThat(Hibernate.isInitialized(product.getMaker())).isTrue();
 	}
 
 	@Transactional

--- a/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/Product.java
+++ b/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/Product.java
@@ -21,6 +21,9 @@ public class Product {
 	public static final String DEFAULT_EG = "Product.default";
 	public static final String BRAND_EG = "Product.brand";
 
+	public static final String BRAND_PROP_NAME = "brand";
+	public static final String MAKER_PROP_NAME = "maker";
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	@Access(value = AccessType.PROPERTY)


### PR DESCRIPTION
Added a `fromAttributePaths(String...)` static to `EntityGraphUtils` which works similarly to [Spring's ad-hoc queries](http://docs.spring.io/spring-data/jpa/docs/current/reference/html/#repositories.query-methods.query-property-expressions) (see 60th example and readme.md diff). It resolves issue #3.