### PR TITLE
Update to Spring Data 2.0.0.RC3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <source.level>1.8</source.level>
-        <spring.data.jpa>2.0.0.BUILD-SNAPSHOT</spring.data.jpa>
+        <spring.data.jpa>2.0.0.RC3</spring.data.jpa>
         <eclipselink>2.6.2</eclipselink>
         <querydsl>4.1.3</querydsl>
 

--- a/src/site/resources/settings.xml
+++ b/src/site/resources/settings.xml
@@ -17,6 +17,11 @@
                     <name>spring-snapshot-local</name>
                     <url>https://repo.spring.io/libs-snapshot-local</url>
                 </repository>
+                <repository>
+                    <id>spring-milestone-local</id>
+                    <name>spring-milestone-local</name>
+                    <url>https://repo.spring.io/libs-milestone-local</url>
+                </repository>
             </repositories>
         </profile>
     </profiles>


### PR DESCRIPTION
This makes it easier for people to clone the repo and build spring-data-jpa-entity-graph:2.0.0-SNAPSHOT locally (as there is no release yet compatible with Spring Boot 2.0)