### PR TITLE
Update Spring Data dependency to 2.0.0.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <source.level>1.8</source.level>
-        <spring.data.jpa>2.0.0.RC3</spring.data.jpa>
+        <spring.data.jpa>2.0.0.RELEASE</spring.data.jpa>
         <eclipselink>2.6.2</eclipselink>
         <querydsl>4.1.3</querydsl>
 


### PR DESCRIPTION
Spring Data 2.0.0 is nog GA. Maybe good time to also release v2.0.0 of this project.