### PR TITLE
Use entity graph type LOAD instead of FETCH

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,15 +12,15 @@
 
   <properties>
     <source.level>1.8</source.level>
-    <spring.data.jpa>2.2.2.RELEASE</spring.data.jpa>
-    <eclipselink>2.6.2</eclipselink>
+    <spring.data.jpa>2.2.6.RELEASE</spring.data.jpa>
+    <eclipselink>2.6.8</eclipselink>
     <querydsl>4.2.1</querydsl>
 
     <!--Test-->
     <dbunit>2.5.3</dbunit>
     <spring-test-dbunit>1.3.0</spring-test-dbunit>
-    <spring.framework.version>5.2.0.RELEASE</spring.framework.version>
-    <hibernate.version>5.4.7.Final</hibernate.version>
+    <spring.framework.version>5.2.5.RELEASE</spring.framework.version>
+    <hibernate.version>5.4.13.Final</hibernate.version>
     <hsqldb.version>2.3.4</hsqldb.version>
     <assertj>3.8.0</assertj>
     <logback>1.2.3</logback>

--- a/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain/AbstractEntityGraph.java
+++ b/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain/AbstractEntityGraph.java
@@ -11,7 +11,7 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class AbstractEntityGraph implements EntityGraph {
 
-  protected static final EntityGraphType DEFAULT_ENTITY_GRAPH_TYPE = EntityGraphType.FETCH;
+  protected static final EntityGraphType DEFAULT_ENTITY_GRAPH_TYPE = EntityGraphType.LOAD;
   private EntityGraphType entityGraphType = DEFAULT_ENTITY_GRAPH_TYPE;
   private boolean optional;
 

--- a/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain/EntityGraphUtils.java
+++ b/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain/EntityGraphUtils.java
@@ -49,4 +49,14 @@ public class EntityGraphUtils {
     Assert.notEmpty(attributePaths, "At least one attribute path is required.");
     return new DynamicEntityGraph(Arrays.asList(attributePaths));
   }
+
+  /**
+   * @param type A {@link EntityGraphType} to use
+   * @param attributePaths The attribute paths to be present in the result
+   * @return A {@link DynamicEntityGraph} with the path attributes passed in as arguments.
+   */
+  public static EntityGraph fromAttributePaths(EntityGraphType type, String... attributePaths) {
+    Assert.notEmpty(attributePaths, "At least one attribute path is required.");
+    return new DynamicEntityGraph(type, Arrays.asList(attributePaths));
+  }
 }

--- a/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/Category.java
+++ b/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/Category.java
@@ -1,0 +1,36 @@
+package com.cosium.spring.data.jpa.entity.graph.repository.sample;
+
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+/** */
+@Entity
+public class Category {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Access(value = AccessType.PROPERTY)
+  private long id = 0;
+
+  private String name;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+}

--- a/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/EntityGraphSpecification.java
+++ b/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/EntityGraphSpecification.java
@@ -32,7 +32,7 @@ public abstract class EntityGraphSpecification<T> implements Specification<T>, E
 
   @Override
   public EntityGraphType getEntityGraphType() {
-    return EntityGraphType.FETCH;
+    return EntityGraphType.LOAD;
   }
 
   @Override

--- a/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/Product.java
+++ b/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/sample/Product.java
@@ -1,6 +1,16 @@
 package com.cosium.spring.data.jpa.entity.graph.repository.sample;
 
-import javax.persistence.*;
+import javax.persistence.Access;
+import javax.persistence.AccessType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
+import javax.persistence.NamedEntityGraphs;
 
 /**
  * Created on 22/11/16.
@@ -43,6 +53,9 @@ public class Product {
   @ManyToOne(fetch = FetchType.LAZY)
   private Maker maker;
 
+  @ManyToOne(fetch = FetchType.EAGER)
+  private Category category;
+
   public long getId() {
     return id;
   }
@@ -81,5 +94,13 @@ public class Product {
 
   public void setBarcode(String barcode) {
     this.barcode = barcode;
+  }
+
+  public Category getCategory() {
+    return category;
+  }
+
+  public void setCategory(Category category) {
+    this.category = category;
   }
 }

--- a/src/test/resources/com/cosium/spring/data/jpa/entity/graph/dataset.xml
+++ b/src/test/resources/com/cosium/spring/data/jpa/entity/graph/dataset.xml
@@ -7,18 +7,20 @@
 
     <maker id="1" name="Maker 1" country_id="1"/>
 
-    <product id="1" name="Product 1" brand_id="1" maker_id="1" barcode="1111"/>
-    <product id="2" name="Product 2" brand_id="1" maker_id="1" barcode="2222"/>
-    <product id="3" name="Product 3" brand_id="2" maker_id="1" barcode="3333"/>
-    <product id="4" name="Product 4" brand_id="2" maker_id="1" barcode="4444"/>
+    <category id="1" name="Category 1" />
 
-    <product id="5" name="Product 5" brand_id="1" maker_id="1" barcode="5555"/>
-    <product id="6" name="Product 6" brand_id="1" maker_id="1" barcode="6666"/>
-    <product id="7" name="Product 7" brand_id="2" maker_id="1" barcode="7777"/>
-    <product id="8" name="Product 8" brand_id="2" maker_id="1" barcode="8888"/>
+    <product id="1" name="Product 1" brand_id="1" maker_id="1" category_id="1" barcode="1111"/>
+    <product id="2" name="Product 2" brand_id="1" maker_id="1" category_id="1" barcode="2222"/>
+    <product id="3" name="Product 3" brand_id="2" maker_id="1" category_id="1" barcode="3333"/>
+    <product id="4" name="Product 4" brand_id="2" maker_id="1" category_id="1" barcode="4444"/>
 
-    <product id="9" name="Product 9" brand_id="1" maker_id="1" barcode="9999"/>
-    <product id="10" name="Product 10" brand_id="1" maker_id="1" barcode="10101010"/>
-    <product id="11" name="Product 11" brand_id="2" maker_id="1" barcode="11111111"/>
-    <product id="12" name="Product 12" brand_id="2" maker_id="1" barcode="12121212"/>
+    <product id="5" name="Product 5" brand_id="1" maker_id="1" category_id="1" barcode="5555"/>
+    <product id="6" name="Product 6" brand_id="1" maker_id="1" category_id="1" barcode="6666"/>
+    <product id="7" name="Product 7" brand_id="2" maker_id="1" category_id="1" barcode="7777"/>
+    <product id="8" name="Product 8" brand_id="2" maker_id="1" category_id="1" barcode="8888"/>
+
+    <product id="9" name="Product 9" brand_id="1" maker_id="1" category_id="1" barcode="9999"/>
+    <product id="10" name="Product 10" brand_id="1" maker_id="1" category_id="1" barcode="10101010"/>
+    <product id="11" name="Product 11" brand_id="2" maker_id="1" category_id="1" barcode="11111111"/>
+    <product id="12" name="Product 12" brand_id="2" maker_id="1" category_id="1" barcode="12121212"/>
 </dataset>


### PR DESCRIPTION
Hibernate 5.4.11 have introduce a breaking change in QueryHint for entity graph. (see https://hibernate.atlassian.net/browse/HHH-8776)

Previously, attributes that are not specified in the entity graph are treated as FetchType.LAZY or FetchType.EAGER depending on the attribute's definition in annotation.
So "fetchgraph" and "loadgraph" was identical.

Now,  with fetchgraph QueryHint, hibernate fetch only attributes included in the entity graph. So attributes not included in the graph should stay unloaded, even if they are declared EAGER.

To keep compatibility with previous version of spring-data-jpa-entity-graph I have switch the default entity graph type to LOAD and add a new method in EntityGraphUtils.java  to be able to choose the EntityGraphType.