### PR TITLE
Fix: Added super to calls in repo implementation.

### DIFF
--- a/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/support/EntityGraphSimpleJpaRepository.java
+++ b/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/support/EntityGraphSimpleJpaRepository.java
@@ -35,67 +35,67 @@ public class EntityGraphSimpleJpaRepository<T, ID> extends SimpleJpaRepository<T
 
   @Override
   public Optional<T> findOne(Specification<T> spec, EntityGraph entityGraph) {
-    return findOne(spec);
+    return super.findOne(spec);
   }
 
   @Override
   public List<T> findAll(Specification<T> spec, EntityGraph entityGraph) {
-    return findAll(spec);
+    return super.findAll(spec);
   }
 
   @Override
   public Page<T> findAll(Specification<T> spec, Pageable pageable, EntityGraph entityGraph) {
-    return findAll(spec, pageable);
+    return super.findAll(spec, pageable);
   }
 
   @Override
   public List<T> findAll(Specification<T> spec, Sort sort, EntityGraph entityGraph) {
-    return findAll(spec, sort);
+    return super.findAll(spec, sort);
   }
 
   @Override
   public <S extends T> Page<S> findAll(
-      Example<S> example, Pageable pageable, EntityGraph entityGraph) {
-    return findAll(example, pageable);
+          Example<S> example, Pageable pageable, EntityGraph entityGraph) {
+    return super.findAll(example, pageable);
   }
 
   @Override
   public <S extends T> Optional<S> findOne(Example<S> example, EntityGraph entityGraph) {
-    return findOne(example);
+    return super.findOne(example);
   }
 
   @Override
   public Optional<T> findById(ID id, EntityGraph entityGraph) {
-    return findById(id);
+    return super.findById(id);
   }
 
   @Override
   public Page<T> findAll(Pageable pageable, EntityGraph entityGraph) {
-    return findAll(pageable);
+    return super.findAll(pageable);
   }
 
   @Override
   public <S extends T> List<S> findAll(Example<S> example, Sort sort, EntityGraph entityGraph) {
-    return findAll(example, sort);
+    return super.findAll(example, sort);
   }
 
   @Override
   public <S extends T> List<S> findAll(Example<S> example, EntityGraph entityGraph) {
-    return findAll(example);
+    return super.findAll(example);
   }
 
   @Override
   public List<T> findAllById(Iterable<ID> ids, EntityGraph entityGraph) {
-    return findAllById(ids);
+    return super.findAllById(ids);
   }
 
   @Override
   public Iterable<T> findAll(Sort sort, EntityGraph entityGraph) {
-    return findAll(sort);
+    return super.findAll(sort);
   }
 
   @Override
   public Iterable<T> findAll(EntityGraph entityGraph) {
-    return findAll();
+    return super.findAll();
   }
 }


### PR DESCRIPTION
I am developing a set of custom spring repos with soft delete logic based on auth context and request params. I wanted to make the system consistent, so just like in your repo I created a custom repo factory bean, custom repo interfaces (overriding all standard JPA repos and EntityGraph repos) and one implementation file with all methods overwritten from the following:
CrudRepository, SortingAndPagingRepository, JpaRepository, ByExampleExecutor, JpaSpecificationExecutor + all the methods from EntityGraph versions of repos.

My SoftDeleteRepoImpl FindAll had additional showDeleted boolean param and it called your FindAll method with EntityGraph param in the implementation. The problem I ran into was that my FindAll implementation was calling your FindAll as expected, but your FindAll was calling another signature from my implementation again, which added the soft delete logic twice in an inconsistent way. The fix was to add super to the calls you do under the hood in your repo implementation. 

If this is an acceptable change, please accept the PR.
