### PR TITLE
@Embeddable attributes are ignored by the generator

### DIFF
--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/GeneratedEntityGraphTest.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/GeneratedEntityGraphTest.java
@@ -46,9 +46,8 @@ class GeneratedEntityGraphTest extends BaseTest {
 
   @Test
   @DisplayName("EntityGraph with embedded part is well generated")
-  @Transactional
   void test2() {
-    ProductEntityGraph.____().tracking().creator().____.tracking().modifier().____.____();
+    ProductEntityGraph.____().tracking().modifier().____.____();
   }
 
   public interface ProductRepository extends EntityGraphCrudRepository<Product, Long> {}

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/GeneratedEntityGraphTest.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/GeneratedEntityGraphTest.java
@@ -8,6 +8,7 @@ import com.cosium.spring.data.jpa.entity.graph.sample.ProductEntityGraph;
 import com.github.springtestdbunit.annotation.DatabaseSetup;
 import javax.inject.Inject;
 import org.hibernate.Hibernate;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +42,13 @@ class GeneratedEntityGraphTest extends BaseTest {
     assertThat(Hibernate.isInitialized(product.getCategory())).isTrue();
     assertThat(Hibernate.isInitialized(product.getMaker())).isTrue();
     assertThat(Hibernate.isInitialized(product.getMaker().getCountry())).isTrue();
+  }
+
+  @Test
+  @DisplayName("EntityGraph with embedded part is well generated")
+  @Transactional
+  void test2() {
+    ProductEntityGraph.____().tracking().creator().____.tracking().modifier().____.____();
   }
 
   public interface ProductRepository extends EntityGraphCrudRepository<Product, Long> {}

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Product.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Product.java
@@ -5,6 +5,7 @@ import jakarta.persistence.AccessType;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Embedded;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -43,6 +44,8 @@ public class Product {
   @Access(value = AccessType.PROPERTY)
   private long id = 0;
 
+  @Embedded private Tracking tracking;
+
   private String name;
 
   private String barcode;
@@ -73,6 +76,14 @@ public class Product {
 
   public void setId(long id) {
     this.id = id;
+  }
+
+  public Tracking getTracking() {
+    return tracking;
+  }
+
+  public void setTracking(Tracking tracking) {
+    this.tracking = tracking;
   }
 
   public String getName() {

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Product.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Product.java
@@ -78,14 +78,6 @@ public class Product {
     this.id = id;
   }
 
-  public Tracking getTracking() {
-    return tracking;
-  }
-
-  public void setTracking(Tracking tracking) {
-    this.tracking = tracking;
-  }
-
   public String getName() {
     return name;
   }

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Tracking.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Tracking.java
@@ -8,23 +8,4 @@ import jakarta.persistence.ManyToOne;
 public class Tracking {
   @ManyToOne(fetch = FetchType.LAZY)
   private User modifier;
-
-  @ManyToOne(fetch = FetchType.LAZY)
-  private User creator;
-
-  public User getModifier() {
-    return modifier;
-  }
-
-  public void setModifier(User modifier) {
-    this.modifier = modifier;
-  }
-
-  public User getCreator() {
-    return creator;
-  }
-
-  public void setCreator(User creator) {
-    this.creator = creator;
-  }
 }

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Tracking.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Tracking.java
@@ -1,0 +1,30 @@
+package com.cosium.spring.data.jpa.entity.graph.sample;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ManyToOne;
+
+@Embeddable
+public class Tracking {
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User modifier;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User creator;
+
+  public User getModifier() {
+    return modifier;
+  }
+
+  public void setModifier(User modifier) {
+    this.modifier = modifier;
+  }
+
+  public User getCreator() {
+    return creator;
+  }
+
+  public void setCreator(User creator) {
+    this.creator = creator;
+  }
+}

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
@@ -15,4 +15,12 @@ public class User {
   private long id = 0;
 
   private String login;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
 }

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
@@ -15,20 +15,4 @@ public class User {
   private long id = 0;
 
   private String login;
-
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public String getLogin() {
-    return login;
-  }
-
-  public void setLogin(String login) {
-    this.login = login;
-  }
 }

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
@@ -1,0 +1,34 @@
+package com.cosium.spring.data.jpa.entity.graph.sample;
+
+import jakarta.persistence.Access;
+import jakarta.persistence.AccessType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class User {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Access(value = AccessType.PROPERTY)
+  private long id = 0;
+
+  private String login;
+
+  public long getId() {
+    return id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public String getLogin() {
+    return login;
+  }
+
+  public void setLogin(String login) {
+    this.login = login;
+  }
+}

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/User.java
@@ -12,7 +12,7 @@ public class User {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Access(value = AccessType.PROPERTY)
-  private long id = 0;
+  private long id;
 
   private String login;
 

--- a/core/src/test/resources/com/cosium/spring/data/jpa/entity/graph/dataset.xml
+++ b/core/src/test/resources/com/cosium/spring/data/jpa/entity/graph/dataset.xml
@@ -9,20 +9,22 @@
 
     <category id="1" name="Category 1" />
 
-    <product id="1" name="Product 1" brand_id="1" maker_id="1" category_id="1" barcode="1111"/>
-    <product id="2" name="Product 2" brand_id="1" maker_id="1" category_id="1" barcode="2222"/>
-    <product id="3" name="Product 3" brand_id="2" maker_id="1" category_id="1" barcode="3333"/>
-    <product id="4" name="Product 4" brand_id="2" maker_id="1" category_id="1" barcode="4444"/>
+    <user id="1" login="toto"/>
 
-    <product id="5" name="Product 5" brand_id="1" maker_id="1" category_id="1" barcode="5555"/>
-    <product id="6" name="Product 6" brand_id="1" maker_id="1" category_id="1" barcode="6666"/>
-    <product id="7" name="Product 7" brand_id="2" maker_id="1" category_id="1" barcode="7777"/>
-    <product id="8" name="Product 8" brand_id="2" maker_id="1" category_id="1" barcode="8888"/>
+    <product id="1" name="Product 1" brand_id="1" maker_id="1" category_id="1" barcode="1111" creator_id="1" modifier_id="1"/>
+    <product id="2" name="Product 2" brand_id="1" maker_id="1" category_id="1" barcode="2222" creator_id="1" modifier_id="1"/>
+    <product id="3" name="Product 3" brand_id="2" maker_id="1" category_id="1" barcode="3333" creator_id="1" modifier_id="1"/>
+    <product id="4" name="Product 4" brand_id="2" maker_id="1" category_id="1" barcode="4444" creator_id="1" modifier_id="1"/>
 
-    <product id="9" name="Product 9" brand_id="1" maker_id="1" category_id="1" barcode="9999"/>
-    <product id="10" name="Product 10" brand_id="1" maker_id="1" category_id="1" barcode="10101010"/>
-    <product id="11" name="Product 11" brand_id="2" maker_id="1" category_id="1" barcode="11111111"/>
-    <product id="12" name="Product 12" brand_id="2" maker_id="1" category_id="1" barcode="12121212"/>
+    <product id="5" name="Product 5" brand_id="1" maker_id="1" category_id="1" barcode="5555" creator_id="1" modifier_id="1"/>
+    <product id="6" name="Product 6" brand_id="1" maker_id="1" category_id="1" barcode="6666" creator_id="1" modifier_id="1"/>
+    <product id="7" name="Product 7" brand_id="2" maker_id="1" category_id="1" barcode="7777" creator_id="1" modifier_id="1"/>
+    <product id="8" name="Product 8" brand_id="2" maker_id="1" category_id="1" barcode="8888" creator_id="1" modifier_id="1"/>
+
+    <product id="9" name="Product 9" brand_id="1" maker_id="1" category_id="1" barcode="9999" creator_id="1" modifier_id="1"/>
+    <product id="10" name="Product 10" brand_id="1" maker_id="1" category_id="1" barcode="10101010" creator_id="1" modifier_id="1"/>
+    <product id="11" name="Product 11" brand_id="2" maker_id="1" category_id="1" barcode="11111111" creator_id="1" modifier_id="1"/>
+    <product id="12" name="Product 12" brand_id="2" maker_id="1" category_id="1" barcode="12121212" creator_id="1" modifier_id="1"/>
 
     <defaultentitygraphtest_entity id="1" maker_id="1"/>
 </dataset>

--- a/core/src/test/resources/com/cosium/spring/data/jpa/entity/graph/dataset.xml
+++ b/core/src/test/resources/com/cosium/spring/data/jpa/entity/graph/dataset.xml
@@ -7,24 +7,24 @@
 
     <maker id="1" name="Maker 1" country_id="1"/>
 
-    <category id="1" name="Category 1" />
+    <category id="1" name="Category 1"/>
 
     <user id="1" login="toto"/>
 
-    <product id="1" name="Product 1" brand_id="1" maker_id="1" category_id="1" barcode="1111" creator_id="1" modifier_id="1"/>
-    <product id="2" name="Product 2" brand_id="1" maker_id="1" category_id="1" barcode="2222" creator_id="1" modifier_id="1"/>
-    <product id="3" name="Product 3" brand_id="2" maker_id="1" category_id="1" barcode="3333" creator_id="1" modifier_id="1"/>
-    <product id="4" name="Product 4" brand_id="2" maker_id="1" category_id="1" barcode="4444" creator_id="1" modifier_id="1"/>
+    <product id="1" name="Product 1" brand_id="1" maker_id="1" category_id="1" barcode="1111" modifier_id="1"/>
+    <product id="2" name="Product 2" brand_id="1" maker_id="1" category_id="1" barcode="2222" modifier_id="1"/>
+    <product id="3" name="Product 3" brand_id="2" maker_id="1" category_id="1" barcode="3333" modifier_id="1"/>
+    <product id="4" name="Product 4" brand_id="2" maker_id="1" category_id="1" barcode="4444" modifier_id="1"/>
 
-    <product id="5" name="Product 5" brand_id="1" maker_id="1" category_id="1" barcode="5555" creator_id="1" modifier_id="1"/>
-    <product id="6" name="Product 6" brand_id="1" maker_id="1" category_id="1" barcode="6666" creator_id="1" modifier_id="1"/>
-    <product id="7" name="Product 7" brand_id="2" maker_id="1" category_id="1" barcode="7777" creator_id="1" modifier_id="1"/>
-    <product id="8" name="Product 8" brand_id="2" maker_id="1" category_id="1" barcode="8888" creator_id="1" modifier_id="1"/>
+    <product id="5" name="Product 5" brand_id="1" maker_id="1" category_id="1" barcode="5555" modifier_id="1"/>
+    <product id="6" name="Product 6" brand_id="1" maker_id="1" category_id="1" barcode="6666" modifier_id="1"/>
+    <product id="7" name="Product 7" brand_id="2" maker_id="1" category_id="1" barcode="7777" modifier_id="1"/>
+    <product id="8" name="Product 8" brand_id="2" maker_id="1" category_id="1" barcode="8888" modifier_id="1"/>
 
-    <product id="9" name="Product 9" brand_id="1" maker_id="1" category_id="1" barcode="9999" creator_id="1" modifier_id="1"/>
-    <product id="10" name="Product 10" brand_id="1" maker_id="1" category_id="1" barcode="10101010" creator_id="1" modifier_id="1"/>
-    <product id="11" name="Product 11" brand_id="2" maker_id="1" category_id="1" barcode="11111111" creator_id="1" modifier_id="1"/>
-    <product id="12" name="Product 12" brand_id="2" maker_id="1" category_id="1" barcode="12121212" creator_id="1" modifier_id="1"/>
+    <product id="9" name="Product 9" brand_id="1" maker_id="1" category_id="1" barcode="9999" modifier_id="1"/>
+    <product id="10" name="Product 10" brand_id="1" maker_id="1" category_id="1" barcode="10101010" modifier_id="1"/>
+    <product id="11" name="Product 11" brand_id="2" maker_id="1" category_id="1" barcode="11111111" modifier_id="1"/>
+    <product id="12" name="Product 12" brand_id="2" maker_id="1" category_id="1" barcode="12121212" modifier_id="1"/>
 
     <defaultentitygraphtest_entity id="1" maker_id="1"/>
 </dataset>

--- a/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttribute.java
+++ b/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttribute.java
@@ -75,7 +75,7 @@ public class MetamodelAttribute {
       return Optional.empty();
     }
 
-    if (!isRelatedToEntityConcept(targetTypeElement) && !pluralAttribute) {
+    if (!canCarryEntityGraphAttribute(targetTypeElement) && !pluralAttribute) {
       return Optional.empty();
     }
 
@@ -84,7 +84,7 @@ public class MetamodelAttribute {
             variableElement.getSimpleName().toString(), targetTypeElement));
   }
 
-  private boolean isRelatedToEntityConcept(TypeElement targetTypeElement) {
+  private boolean canCarryEntityGraphAttribute(TypeElement targetTypeElement) {
     return targetTypeElement.getAnnotation(Entity.class) != null
         || targetTypeElement.getAnnotation(Embeddable.class) != null;
   }

--- a/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttribute.java
+++ b/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttribute.java
@@ -2,6 +2,7 @@ package com.cosium.spring.data.jpa.graph.generator;
 
 import static javax.lang.model.element.ElementKind.*;
 
+import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import jakarta.persistence.metamodel.Attribute;
 import jakarta.persistence.metamodel.PluralAttribute;
@@ -74,7 +75,9 @@ public class MetamodelAttribute {
       return Optional.empty();
     }
 
-    if (targetTypeElement.getAnnotation(Entity.class) == null && !pluralAttribute) {
+    if ((targetTypeElement.getAnnotation(Entity.class) == null
+            && targetTypeElement.getAnnotation(Embeddable.class) == null)
+        && !pluralAttribute) {
       return Optional.empty();
     }
 

--- a/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttribute.java
+++ b/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttribute.java
@@ -75,14 +75,17 @@ public class MetamodelAttribute {
       return Optional.empty();
     }
 
-    if ((targetTypeElement.getAnnotation(Entity.class) == null
-            && targetTypeElement.getAnnotation(Embeddable.class) == null)
-        && !pluralAttribute) {
+    if (!isRelatedToEntityConcept(targetTypeElement) && !pluralAttribute) {
       return Optional.empty();
     }
 
     return Optional.of(
         new MetamodelAttributeTarget(
             variableElement.getSimpleName().toString(), targetTypeElement));
+  }
+
+  private boolean isRelatedToEntityConcept(TypeElement targetTypeElement) {
+    return targetTypeElement.getAnnotation(Entity.class) != null
+        || targetTypeElement.getAnnotation(Embeddable.class) != null;
   }
 }

--- a/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttributeTarget.java
+++ b/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/MetamodelAttributeTarget.java
@@ -2,6 +2,7 @@ package com.cosium.spring.data.jpa.graph.generator;
 
 import static java.util.Objects.requireNonNull;
 
+import jakarta.persistence.Embeddable;
 import jakarta.persistence.Entity;
 import javax.lang.model.element.TypeElement;
 
@@ -13,11 +14,13 @@ public class MetamodelAttributeTarget {
   private final String attributeName;
   private final TypeElement targetType;
   private final Entity entityAnnotation;
+  private final Embeddable embeddableAnnotation;
 
   public MetamodelAttributeTarget(String attributeName, TypeElement targetType) {
     this.attributeName = requireNonNull(attributeName);
     this.targetType = requireNonNull(targetType);
     this.entityAnnotation = targetType.getAnnotation(Entity.class);
+    this.embeddableAnnotation = targetType.getAnnotation(Embeddable.class);
   }
 
   public String attributeName() {
@@ -30,5 +33,9 @@ public class MetamodelAttributeTarget {
 
   public boolean isEntity() {
     return entityAnnotation != null;
+  }
+
+  public boolean isEmbeddable() {
+    return embeddableAnnotation != null;
   }
 }

--- a/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/NodeComposer.java
+++ b/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/NodeComposer.java
@@ -60,7 +60,7 @@ public class NodeComposer implements Composer {
 
   @Override
   public void addPath(Elements elements, MetamodelAttributeTarget target) {
-    if (target.isEntity()) {
+    if (target.isEntity() || target.isEmbeddable()) {
       addPathToEntity(elements, target);
     } else {
       referencesLeafComposer = true;

--- a/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/RootComposer.java
+++ b/generator/src/main/java/com/cosium/spring/data/jpa/graph/generator/RootComposer.java
@@ -80,7 +80,7 @@ public class RootComposer implements Composer {
 
   @Override
   public void addPath(Elements elements, MetamodelAttributeTarget target) {
-    if (target.isEntity()) {
+    if (target.isEntity() || target.isEmbeddable()) {
       addPathToEntity(elements, target);
     } else {
       referencesLeafComposer = true;


### PR DESCRIPTION
Hi,

I have following related tables: 
```java
@Entity
public class Product {
  @Id
  @GeneratedValue(strategy = GenerationType.IDENTITY)
  @Access(value = AccessType.PROPERTY)
  private long id = 0;

  @Embedded private Tracking tracking;

  private String barcode;
  
  ....
}

@Embeddable
public class Tracking {
  @ManyToOne(fetch = FetchType.LAZY)
  private User modifier;

  @ManyToOne(fetch = FetchType.LAZY)
  private User creator;
}
```

GeneratedEntityGraph does not contains `tracking` relation.

With this pull request `spring-data-jpa-entity-graph` will be able to generate it. 