### PR TITLE
Nullsafe

### DIFF
--- a/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/support/EntityGraphQueryHintCandidates.java
+++ b/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/support/EntityGraphQueryHintCandidates.java
@@ -136,7 +136,7 @@ class EntityGraphQueryHintCandidates implements MethodInterceptor {
       return true;
     }
     for (Class<?> genericType : repositoryMethodReturnType.resolveGenerics()) {
-      if (domainClass.isAssignableFrom(genericType)) {
+      if (genericType != null && domainClass.isAssignableFrom(genericType)) {
         return true;
       }
     }


### PR DESCRIPTION
resolveGenerics doc:
Returns: an array of resolved generic parameters (the resulting array will never be null, but it **may contain null elements**)