### PR TITLE
Test case for envers incompatibility

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -102,6 +102,12 @@
       <artifactId>logback-classic</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.data</groupId>
+      <artifactId>spring-data-envers</artifactId>
+      <version>${spring.data.jpa}</version>
+      <scope>test</scope>
+     </dependency>
   </dependencies>
 
   <build>

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/DataRepositoryEnversConfiguration.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/DataRepositoryEnversConfiguration.java
@@ -1,0 +1,56 @@
+package com.cosium.spring.data.jpa.entity.graph;
+
+import com.cosium.spring.data.jpa.entity.graph.repository.support.EntityGraphJpaRepositoryFactoryBean;
+import javax.sql.DataSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.envers.repository.config.EnableEnversRepositories;
+import org.springframework.jdbc.datasource.SingleConnectionDataSource;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.Database;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+/**
+ * Created on 22/11/16.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+@Configuration
+@EnableEnversRepositories(
+    basePackages = "com.cosium.spring.data.jpa.entity.graph",
+    repositoryFactoryBeanClass = EntityGraphJpaRepositoryFactoryBean.class,
+    considerNestedRepositories = true)
+@EnableTransactionManagement
+@ComponentScan
+public class DataRepositoryEnversConfiguration {
+
+  @Bean
+  public PlatformTransactionManager transactionManager() {
+    return new JpaTransactionManager();
+  }
+
+  @Bean
+  public DataSource dataSource() {
+    return new SingleConnectionDataSource("jdbc:hsqldb:mem:.", "sa", "", true);
+  }
+
+  @Bean
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory() {
+
+    LocalContainerEntityManagerFactoryBean factory = new LocalContainerEntityManagerFactoryBean();
+    factory.setDataSource(dataSource());
+    factory.setMappingResources("META-INF/orm.xml");
+    factory.setPackagesToScan("com.cosium.spring.data.jpa.entity.graph");
+
+    HibernateJpaVendorAdapter jpaVendorAdapter = new HibernateJpaVendorAdapter();
+    jpaVendorAdapter.setDatabase(Database.H2);
+    jpaVendorAdapter.setGenerateDdl(true);
+    factory.setJpaVendorAdapter(jpaVendorAdapter);
+
+    return factory;
+  }
+}

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/EnversRepositoryTest.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/EnversRepositoryTest.java
@@ -1,0 +1,94 @@
+package com.cosium.spring.data.jpa.entity.graph.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.cosium.spring.data.jpa.entity.graph.DataRepositoryEnversConfiguration;
+import com.cosium.spring.data.jpa.entity.graph.domain2.EntityGraph;
+import com.cosium.spring.data.jpa.entity.graph.domain2.NamedEntityGraph;
+import com.cosium.spring.data.jpa.entity.graph.sample.Maker;
+import com.cosium.spring.data.jpa.entity.graph.sample.MakerEntityGraph;
+import com.github.springtestdbunit.DbUnitTestExecutionListener;
+import java.util.List;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import org.hibernate.Hibernate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.history.RevisionRepository;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.support.DependencyInjectionTestExecutionListener;
+import org.springframework.test.context.support.DirtiesContextTestExecutionListener;
+import org.springframework.test.context.transaction.TransactionalTestExecutionListener;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Created on 17/03/17.
+ *
+ * @author Reda.Housni-Alaoui
+ */
+@TestExecutionListeners({
+  DependencyInjectionTestExecutionListener.class,
+  DirtiesContextTestExecutionListener.class,
+  TransactionalTestExecutionListener.class,
+  DbUnitTestExecutionListener.class
+})
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = {DataRepositoryEnversConfiguration.class})
+@DirtiesContext
+class EnversRepositoryTest {
+
+  @Inject private MakerRepository makerRepository;
+
+  @Transactional
+  @Test
+  @DisplayName("Given noop eg when finding makers then country should not be initialized")
+  void test1() {
+    List<Maker> makers = makerRepository.findByName("Maker 1", EntityGraph.NOOP);
+    assertThat(makers).isNotEmpty();
+    for (Maker maker : makers) {
+      assertThat(Hibernate.isInitialized(maker.getCountry())).isFalse();
+    }
+  }
+
+  @Transactional
+  @Test
+  @DisplayName("Given country eg when finding makers then country should be initialized")
+  void test2() {
+    List<Maker> makers =
+        makerRepository.findByName("Maker 1", NamedEntityGraph.loading(Maker.COUNTRY_EG));
+    assertThat(makers).isNotEmpty();
+    for (Maker maker : makers) {
+      assertThat(Hibernate.isInitialized(maker.getCountry())).isTrue();
+    }
+  }
+
+  @Transactional
+  @Test
+  @DisplayName(
+      "Given noop eg from generated eg when finding makers then country should not be initialized")
+  void test3() {
+    List<Maker> makers = makerRepository.findByName("Maker 1", MakerEntityGraph.NOOP);
+    assertThat(makers).isNotEmpty();
+    for (Maker maker : makers) {
+      assertThat(Hibernate.isInitialized(maker.getCountry())).isFalse();
+    }
+  }
+
+  /**
+   * Created on 17/03/17.
+   *
+   * @author Reda.Housni-Alaoui
+   */
+  public interface MakerRepository
+      extends Repository<Maker, Long>, RevisionRepository<Maker, Long, Long> {
+
+    List<Maker> findByName(String name, EntityGraph entityGraph);
+
+    Stream<Maker> readByName(String name, EntityGraph entityGraph);
+  }
+}


### PR DESCRIPTION
Related to

https://github.com/Cosium/spring-data-jpa-entity-graph/issues/180

Test fails with
Caused by: org.springframework.data.mapping.PropertyReferenceException: No property 'findRevisions' found for type 'Maker'