### PR TITLE
chore(deps): Update Spring Data JPA to 3.5.0

### DIFF
--- a/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/query/EntityGraphAwareJpaQueryMethod.java
+++ b/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/query/EntityGraphAwareJpaQueryMethod.java
@@ -5,8 +5,6 @@ import org.springframework.data.jpa.provider.QueryExtractor;
 import org.springframework.data.jpa.repository.query.JpaQueryMethod;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.repository.core.RepositoryMetadata;
-import org.springframework.data.repository.query.Parameters;
-import org.springframework.data.repository.query.ParametersSource;
 
 /**
  * @author Réda Housni Alaoui

--- a/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/query/EntityGraphAwareJpaQueryMethod.java
+++ b/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/repository/query/EntityGraphAwareJpaQueryMethod.java
@@ -18,11 +18,6 @@ class EntityGraphAwareJpaQueryMethod extends JpaQueryMethod {
       RepositoryMetadata metadata,
       ProjectionFactory factory,
       QueryExtractor extractor) {
-    super(method, metadata, factory, extractor);
-  }
-
-  @Override
-  protected Parameters<?, ?> createParameters(ParametersSource parametersSource) {
-    return new EntityGraphAwareJpaParameters(parametersSource);
+    super(method, metadata, factory, extractor, EntityGraphAwareJpaParameters::new);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <properties>
     <maven.compiler.release>17</maven.compiler.release>
 
-    <spring.data.jpa>3.2.1</spring.data.jpa>
+    <spring.data.jpa>3.5.0</spring.data.jpa>
     <querydsl>5.1.0</querydsl>
 
     <dbunit>3.0.0</dbunit>


### PR DESCRIPTION
Adapted EntityGraphAwareJpaQueryMethod to the updated JpaQueryMethod constructor signature. The constructor now accepts a ParametersSource supplier directly, removing the need to override createParameters.