### PR TITLE
Fluent querying can lead to invalid entity graph if multiple children nodes of a same child node are queried #318

### DIFF
--- a/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain2/EntityGraphQueryHint.java
+++ b/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain2/EntityGraphQueryHint.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
+import org.jspecify.annotations.Nullable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor.SpecificationFluentQuery;
 
 /**
@@ -55,19 +57,27 @@ public class EntityGraphQueryHint {
   private Collection<String> toProperties() {
     List<String> paths = new ArrayList<>();
     for (AttributeNode<?> node : entityGraph.getAttributeNodes()) {
-      List<String> nodePath = new ArrayList<>();
-      addPath(node, nodePath);
-      paths.add(String.join(".", nodePath));
+      visitNode(node, null, paths);
     }
     Collections.sort(paths);
     return paths;
   }
 
-  private void addPath(AttributeNode<?> node, List<String> path) {
-    path.add(node.getAttributeName());
+  private void visitNode(
+      AttributeNode<?> node, @Nullable String parentPath, List<String> collectedPaths) {
+    String visitedPath =
+        Optional.ofNullable(parentPath)
+            .map(path -> path + "." + node.getAttributeName())
+            .orElseGet(node::getAttributeName);
+
+    if (node.getSubgraphs().isEmpty()) {
+      collectedPaths.add(visitedPath);
+      return;
+    }
+
     for (Subgraph<?> subgraph : node.getSubgraphs().values()) {
-      for (AttributeNode<?> attributeNode : subgraph.getAttributeNodes()) {
-        addPath(attributeNode, path);
+      for (AttributeNode<?> childNode : subgraph.getAttributeNodes()) {
+        visitNode(childNode, visitedPath, collectedPaths);
       }
     }
   }

--- a/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain2/EntityGraphQueryHint.java
+++ b/core/src/main/java/com/cosium/spring/data/jpa/entity/graph/domain2/EntityGraphQueryHint.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.jspecify.annotations.Nullable;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor.SpecificationFluentQuery;
@@ -70,12 +71,13 @@ public class EntityGraphQueryHint {
             .map(path -> path + "." + node.getAttributeName())
             .orElseGet(node::getAttributeName);
 
-    if (node.getSubgraphs().isEmpty()) {
+    Map<Class, Subgraph> subgraphs = node.getSubgraphs();
+    if (subgraphs.isEmpty()) {
       collectedPaths.add(visitedPath);
       return;
     }
 
-    for (Subgraph<?> subgraph : node.getSubgraphs().values()) {
+    for (Subgraph<?> subgraph : subgraphs.values()) {
       for (AttributeNode<?> childNode : subgraph.getAttributeNodes()) {
         visitNode(childNode, visitedPath, collectedPaths);
       }

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/FluentQueryTest.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/repository/FluentQueryTest.java
@@ -155,6 +155,27 @@ class FluentQueryTest extends BaseTest {
     assertThat(Hibernate.isInitialized(product.getMaker().getCountry())).isFalse();
   }
 
+  @Transactional
+  @Test
+  @DisplayName("It supports entity graph having a child node with at least 2 children itself")
+  void test9() {
+    Slice<Product> products =
+        productRepository.findBy(
+            idEquals(1L),
+            ProductEntityGraph.____().brand().____.maker().country().____.maker().ceo().____.____(),
+            query -> query.slice(Pageable.ofSize(1)));
+
+    assertThat(products).hasSize(1);
+
+    Product product = products.stream().findFirst().orElseThrow();
+    assertThat(Hibernate.isInitialized(product.getBrand())).isTrue();
+    assertThat(Hibernate.isInitialized(product.getMaker())).isTrue();
+    assertThat(Hibernate.isInitialized(product.getMaker().getCountry())).isTrue();
+    assertThat(Hibernate.isInitialized(product.getMaker().getCeo())).isTrue();
+
+    assertThat(Hibernate.isInitialized(product.getCategory())).isFalse();
+  }
+
   private static Specification<Product> idEquals(long id) {
     return (root, query, cb) -> cb.equal(root.get(Product_.id), id);
   }

--- a/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Maker.java
+++ b/core/src/test/java/com/cosium/spring/data/jpa/entity/graph/sample/Maker.java
@@ -45,6 +45,9 @@ public class Maker {
   @OneToMany(fetch = FetchType.LAZY, mappedBy = "maker")
   private final Set<Product> products = new LinkedHashSet<>();
 
+  @ManyToOne(fetch = FetchType.LAZY)
+  private User ceo;
+
   public long getId() {
     return id;
   }
@@ -71,5 +74,13 @@ public class Maker {
 
   public Set<Product> getProducts() {
     return products;
+  }
+
+  public User getCeo() {
+    return ceo;
+  }
+
+  public void setCeo(User owner) {
+    this.ceo = owner;
   }
 }


### PR DESCRIPTION
Fix #318 